### PR TITLE
Create an invocation method with Checklists and Controls

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,7 +5,7 @@
 #+FILETAGS: PowerShell compliance Pester
 
   | Status:   | Under Development (Pre-release) |
-  | Location: | [[https://github.com/aldrichtr/infraspective][github]]                  |
+  | Location: | [[https://github.com/aldrichtr/infraspective][github]]                          |
   | Version:  | 0.0.1                           |
 
 * Synopsis
@@ -13,26 +13,76 @@
 [[https://pester.dev][Pester Testing Module]] .
 
 * Description
-  ~infraspective~ reads tests (written in [[https://www.agilealliance.org/glossary/bdd/][BDD style]] , like Pester) and produces output that reports on compliance of your
-  infrastructure to those tests.
+  ~infraspective~ reads tests (written in [[https://www.agilealliance.org/glossary/bdd/][BDD style]] , like Pester) and produces output that reports on compliance
+  of your infrastructure to those tests.
 
+  Originally, [[https://github.com/PowerShell/Operation-Validation-Framework][Operation Validation Framework]] used Pester tests organized in particular directories in your module.
+  [[https://github.com/TicketMaster/poshspec][poshspec]] added a DSL for making those tests more expressive.  =infraspective= picks up where they left off, using
+  modern Pester (there were some [[https://pester.dev/docs/migrations/breaking-changes-in-v5][breaking changes]] from v4 to v5) and adds in some concepts from other tools to
+  create a Policy as Code tool.
+
+  Starting with a test like:
+  #+begin_src powershell
+    Describe "Services" {
+        It "DNS Service should be running" {
+            $dns_service = Get-Service -Name 'DNS'
+            $dns_service.Status | Should -Be Running
+        }
+    }
+  #+end_src
+
+  poshspec gave us the ability to write this like:
+
+  #+begin_src powershell
+    Describe "Services" {
+        Service DNS Status { Should -Be Running }
+        # i fixed it up for v5 a little
+    }
+  #+end_src
+
+  Adding some metadata (and some industry terms to the DSL) we have a =Control=
+
+  #+begin_src powershell
+   Control "xccdf_control_123" -Resource "Windows" -Impact 1 -Reference 'CVE:123' {
+        Describe "cis control 123" {
+            It "Should have DNS service running" {
+                Service DNS Status { Should -Be Running }
+            }
+        }
+    }
+  #+end_src
+
+  Next, one or more Controls together create a =Checklist=
+
+  #+begin_src powershell
+    Checklist "Security Audit" -Version "1.0.0" {
+        Control "xccdf_control_123" -Resource "Windows" -Impact 1 -Reference 'CVE:123' {
+            Describe "cis control 123" {
+                It "Should have DNS service running" {
+                    Service DNS Status { Should -Be Running }
+                }
+            }
+        }
+
+        Control "xccdf_control_124" -Resource "Windows" -Impact 1 -Reference 'CVE:124' {
+            Describe "cis control 124" {
+                It "Should have DNS service running" {
+                    Service DNS Status { Should -Be Running }
+                }
+            }
+        
+    }
+  #+end_src
+
+
+  By convention, =Checklists= are stored in files name *.Audit.ps1 , and they can be run by calling
+  =Invoke-Infraspective <directory>=
+  
 * Example
   #+begin_src powershell
     Import-Module infraspective
     Set-Alias infspec Invoke-Infraspective
-    infspec .\cis-controls-windows-server-2019.ps1
+    infspec <path/to/files>
   #+end_src
-
-  #+begin_example
-    
-  #+end_example
-* Notes
-  There are several tools out there that do compliance testing for your infrastructure, such as [[https://docs.chef.io/inspec][chef inspec]] or
-  [[https://docs.cfengine.com/docs/3.18][cfengine]] .  Other tools (particularly automation tools) offer some infrastructure testing capabilities such as 
-  ansible, puppet, terraform and Desired State Configuration (DSC), although their focus is on _applying_ controls
-  to the infrastructure rather than reporting.
-
-  Other projects have a similar idea; Operation Validation Framework and PoshSpec are two examples.  However, these
-  appear to be abandoned projects.
   
 

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -1,0 +1,22 @@
+@{
+    # used to write logging messages to various targets
+    Logging = @{
+        Version = '4.8.3'
+        Tags    = 'dev', 'prod', 'ci'
+    }
+
+    Configuration = @{
+        Version = '1.5.0'
+        Tags    = 'dev', 'prod', 'ci'
+    }
+    # Not much of a testing application without the testing module
+    Pester  = @{
+        Version = '5.3'
+        Tags    = 'dev', 'prod', 'ci'
+    }
+    # Used to create a new audit folder
+    Plaster = @{
+        Version = '1.1.3'
+        Tags    = 'dev', 'prod', 'ci'
+    }
+}

--- a/source/infraspective/Configuration.psd1
+++ b/source/infraspective/Configuration.psd1
@@ -1,0 +1,66 @@
+<#
+        NOTSET    ( 0)
+        DEBUG     (10)
+        INFO      (20)
+        WARNING   (30)
+        ERROR     (40)
+#>
+
+
+<#
+        The Format property defines how the message is rendered.
+
+        The default value is: [%{timestamp}] [%{level:-7}] %{message}
+
+        The Log object has a number of attributes that are replaced in the format string to produce the message:
+
+        |Format            |                                           Description                                 |
+        |------------------|---------------------------------------------------------------------------------------|
+        | %{timestamp}     | Time when the log message was created. Defaults to %Y-%m-%d %T%Z                      |
+        |                  |     (2016-04-20 14:22:45+02) Take a look at                                           |
+        |                  |     https://technet.microsoft.com/en-us/library/hh849887.aspx#sectionSection7 and     |
+        |                  |     https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.85).aspx                   |
+        | %{timestamputc}  | UTC Time when the log message was created. Defaults to %Y-%m-%d %T%Z                  |
+        |                  |    (2016-04-20 12:22:45+02).                                                          |
+        | %{level}         | Text logging level for the message (DEBUG, INFO, WARNING, ERROR)                      |
+        | %{levelno}       | Number logging level for the message (10, 20, 30, 40)
+        | %{lineno}        | The line number on wich the write occured
+        | %{pathname}      | The path of the caller
+        | %{filename}      | The file name part of the caller
+        | %{caller}        | The caller function name
+        | %{message}       | The logged message
+        | %{body}          | The logged body (json format not pretty printed)
+        | %{execinfo}      | The ErrorRecord catched in a try/catch statement
+        | %{pid}           | The process id of the currently running powershellprocess ($PID)
+
+        After the placeholder name you can pass a padding or a date format string separated by a colon (:):
+
+        Note: A format string starting with a percent symbol (%) will use the UFormat parameter of Get-Date
+#>
+
+@{
+    Logging   = @{
+        'File' = @{
+            PrintBody = $false
+            Append    = $true
+            Encoding  = 'UTF-8'
+            Level     = 'DEBUG'
+            # Format    =
+            # Path supports templating like $Logging.Format
+            Path      = "${env:Temp}\infraspective-%{+%Y%m%d}.log"
+        }
+        'Console' = @{
+            Level = 'DEBUG'
+            Format = '[%{timestamp}] %{level} %{caller} - %{pathname}\%{filename}:%{lineno} - %{message}'
+            ColorMapping = @{
+                'DEBUG'   = 'White'
+                'INFO'    = 'Gray'
+                'WARNING' = 'Yellow'
+                'ERROR'   = 'Red'
+            }
+        }
+    }
+    Checklist = @{
+        Filter = "*.Audit.ps1"
+    }
+}

--- a/source/infraspective/public/Invoke-InfraspecChecklist.ps1
+++ b/source/infraspective/public/Invoke-InfraspecChecklist.ps1
@@ -1,0 +1,71 @@
+
+Set-Alias -Name Checklist -Value 'Invoke-InfspecChecklist' -Description 'Execute a infraspective Checklist'
+
+
+function Invoke-InfspecChecklist {
+    <#
+.SYNOPSIS
+    A collection of security controls to check against one or more systems.
+    #>
+    [CmdletBinding()]
+    param(
+        # A unique name for this checklist
+        [Parameter()]
+        [string]$Name,
+
+        # A unique version for this checklist
+        [Parameter()]
+        [version]$Version,
+
+        # The checklist body containing controls
+        [Parameter()]
+        [scriptblock]$Body,
+
+        <# The Session object has three components
+           - Functions : a Hash of functions to provide to the controls
+           - Variables : An array of Variables to provide to the controls
+           - Arguments : Any runtime arguments to be passed in.
+        #>
+        [Parameter()]
+        [Object]$Session
+    )
+
+    begin {
+        $config = Import-Configuration
+        Write-Log -Level INFO -Message "Evaluating checklist '$Name v$($Version.ToString())"
+        $chk = [PSCustomObject]@{
+            Name    = $Name
+            Version = $Version
+            Result  = @()
+        }
+
+        <#
+        If we want to provide the Controls with any session information, we can do that when we invoke the
+        scriptblock.  This way, we can pass in any type of data we may need, including functions, variables or
+        arguments
+        #>
+        $functionsToDefine = @{}
+        [System.Collections.Generic.List[PSVariable]]$variablesToDefine = @()
+        [Object[]]$invocationArgs    = @()
+
+    }
+    process {
+        Write-Debug "[$((Get-Date).TimeofDay) PROCESS  ] Starting $($myinvocation.mycommand)"
+        try {
+            <#
+             Making a design decision here, using the ternary operator '?' rather than a big if / else
+            #>
+            $functionsToDefine = $PSBoundParameters['Session'] ? $Session.Functions : @{}
+            $variablesToDefine = $PSBoundParameters['Session'] ? $Session.Variables : @()
+            $invocationArgs    = $PSBoundParameters['Session'] ? $Session.Arguments : @()
+            $chk.Result = $Body.InvokeWithContext( $functionsToDefine, $variablesToDefine, $invocationArgs )
+
+        } catch {
+            Write-Log -Level ERROR -Message "There was an error with checklist '$Name-$($Version.ToString())'`n$_"
+        }
+    }
+    end {
+        Write-Log -Level INFO -Message "Completed checklist '$Name v$($Version.ToString())"
+        $chk
+    }
+}

--- a/source/infraspective/public/Invoke-InfraspecControl.ps1
+++ b/source/infraspective/public/Invoke-InfraspecControl.ps1
@@ -1,0 +1,85 @@
+
+Set-Alias -Name Control -Value 'Invoke-InfraspecControl' -Description 'Execute a infraspective Control'
+
+Function Invoke-InfraspecControl {
+    <#
+.SYNOPSIS
+    A security control consisting of one or more tests and metadata about the test.
+.DESCRIPTION
+    This function is aliased by the `Control` keyword, and maps directly to the concept of a Security Control found
+    in many frameworks such as CIS, STIG, HIPAA, etc.  A control consists of one or more tests, such as the
+    existence of a file permission, or the status of a service and maps that to a recommended setting for that test
+    found in one of those frameworks, or your corporate or personal security policy.
+
+    A passing test(s) means that the system under test complies with the given control, while a failing test means
+    that the system is not in compliance
+    The tests are regular Pester tests, using the standard "Describe/Context/It/Should" keywords.  These tests are
+    passed directly to Pester (Invoke-Pester) and the results are returned.
+
+.EXAMPLE
+    ``` powershell
+    Control "xccdf_blah" -Resource "Windows" -Impact 1 -Reference 'CVE:123' {
+        Describe "cis control 123" {
+            It "Should have foo set to bar" {
+                $p.foo | Should -Be "bar"
+            }
+        }
+    }
+    ```
+    #>
+    [CmdletBinding()]
+    param(
+        # The unique ID for this control
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Name,
+
+        # The criticality, if this control fails
+        [Parameter(
+            ValueFromPipeline
+        )]
+        [string]$Impact,
+
+        # The human readable title
+        [Parameter()]
+        [string]$Title,
+
+        # References to external tools and databases
+        [Parameter()]
+        [string[]]$Reference,
+
+        # Tags associated with this control
+        [Parameter()]
+        [string[]]
+        $Tags,
+
+        # The type of resource to test
+        [Parameter()]
+        [string]$Resource,
+
+        # An optional description of the test
+        [Parameter()]
+        [string[]]$Description,
+
+        # The tests associated with this control
+        [Parameter(Position = 1)]
+        [ValidateNotNull()]
+        [scriptblock]$Test
+    )
+    begin {
+        $config = New-PesterConfiguration @{
+            Run = @{
+                PassThru = $true
+            }
+            Output = @{
+                Verbosity = 'None'
+            }
+        }
+    }
+    process {
+        $container = New-PesterContainer -ScriptBlock $Test
+        $result = Invoke-Pester -Container $container -Output 'None' -PassThru
+    }
+    end {
+        $result
+    }
+}

--- a/source/infraspective/public/Invoke-Infraspective.ps1
+++ b/source/infraspective/public/Invoke-Infraspective.ps1
@@ -1,0 +1,37 @@
+
+function Invoke-Infraspective {
+    <#
+    .SYNOPSIS
+
+    #>
+    [CmdletBinding()]
+    param(
+        # Path to the Infraspective Checklists folder
+        [Parameter(
+        )]
+        [string]
+        $Path
+    )
+
+    begin {
+        $config = Import-Configuration
+        $logging = $config.Logging
+        foreach ($target in $logging.Keys) {
+            Add-LoggingTarget -Name $target -Configuration $logging[$target]
+        }
+        Write-Log -Level INFO -Message "$($MyInvocation.MyCommand.Name) Starting"
+
+    }
+    process {
+        Write-Log -Level DEBUG -Message "Looking for audit files in $($Path) using Filter $($config.Checklist.Filter)"
+        $audit_files = Get-ChildItem -Path $Path -Filter $config.Checklist.Filter
+        Write-Log -Level DEBUG -Message "Found $($audit_files.Count) audit files"
+        foreach ($f in $audit_files) {
+            Write-Log -Level DEBUG -Message "Running audit $($f.Name)"
+            & $f.FullName | Write-Output
+        }
+    }
+    end {
+        Write-Log -Level INFO -Message "$($MyInvocation.MyCommand.Name) Complete"
+    }
+}

--- a/tests/data/test-one-dot-zero.Audit.ps1
+++ b/tests/data/test-one-dot-zero.Audit.ps1
@@ -1,0 +1,10 @@
+Checklist "Security Audit" -Version "1.0.0" {
+
+    Control "xccdf_blah" -Resource "Windows" -Impact 1 -Reference 'CVE:123' {
+        Describe "cis control 123" {
+            It "Should have foo set to bar" {
+                $p.foo | Should -Be "bar"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Invocation
This PR creates an entry point for the module by providing `Invoke-Infraspective`.  The function executes tests and returns (currently raw Pester) results to the pipeline.

## Checklist
This PR also creates a `Checklist` alias to the `Invoke-InfraspecChecklist` function, which provides some metadata and a means of grouping `Controls` and their results.

## Control
This PR also creates a `Control` alias to the `Invoke-InfraspecControl` function, which provides tests + metadata.

## Utilities
Finally, this PR also implements a means of configuring the module and a logging facility.