### PR TITLE
Fixed token error in project-automation workflow

### DIFF
--- a/.github/workflows/move-opened-issue-to-project.yml
+++ b/.github/workflows/move-opened-issue-to-project.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           project: Backlog
           column: For Review
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ACTION_ADDTOPROJECT }}
   Personal:
     name: Add issue to my personal project management space
     runs-on: ubuntu-latest


### PR DESCRIPTION
The 'Repo' job needs to use a PAT vice the default 'GITHUB_TOKEN' for adding issues to projects in the local repository

Closes: #39 