### PR TITLE
Fixed syntax errors in issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-issue_bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-issue_bug-report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: Report a bug or defect
 title: "<A description of the problem>"
 labels:
-  - 'type: bug'
+  - 'type:bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/00-issue_bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-issue_bug-report.yml
@@ -15,8 +15,6 @@ body:
       description: What version of infraspective are you running?
       placeholder: What version
       value: v0.1
-    validations:
-      required: false
   - type: textarea
     id: what-happened
     attributes:
@@ -24,8 +22,6 @@ body:
       description: Also tell us, what did you expect to happen?
       placeholder: What happened?
       value: Provide as much detail as you can.
-    validations:
-      required: true
   - type: dropdown
     id: os
     attributes:
@@ -50,8 +46,6 @@ body:
      description: What version of PowerShell did the error occur on?
      placeholder: What version of PowerShell?
      value: Find the version by typing `$psversiontable` on the command line
-     validations:
-      required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/10-issue_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/10-issue_feature-request.yml
@@ -3,14 +3,18 @@ name: Feature request
 description: Suggest an idea for infraspective
 labels:
   - 'type: feature'
-
 body:
   - type: markdown
     attributes:
-     value: >
-     **Thank you for taking the time to suggest a feature**
+     value: |
+       "**Thank you for taking the time to suggest a feature**"
 
-     Before you fill out the form, please search the [list of
-     issues](https://github.com/aldrichtr/infraspective/search?q=is%3Aissue&type=issues)
+       "Before you fill out the form, please search the [list of issues](https://github.com/aldrichtr/infraspective/search?q=is%3Aissue&type=issues)"
 
-     please provide as much detail as possible.
+       "please provide as much detail as possible."
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature or enhancement
+      description: "What would you like to see added or improved?"
+      placeholder: "It would be great if infraspective could ...."

--- a/.github/ISSUE_TEMPLATE/10-issue_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/10-issue_feature-request.yml
@@ -2,7 +2,7 @@
 name: Feature request
 description: Suggest an idea for infraspective
 labels:
-  - 'type: feature'
+  - 'type:feature'
 body:
   - type: markdown
     attributes:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,23 +1,23 @@
 changelog:
   exclude:
     labels:
-      - 'state: exclude-from-release'
+      - 'state:exclude-from-release'
   categories:
     - title: Breaking Changes
       labels:
-        - 'type: breaking-change'
+        - 'type:breaking-change'
 
     - title: Bug fixes
       labels:
-        - 'type: bug'
+        - 'type:bug'
 
     - title: New Features
       labels:
-        - 'type: feature'
+        - 'type:feature'
 
     - title: Notable Improvements
       labels:
-        - 'type: enhancement'
+        - 'type:enhancement'
 
     - title: Other Changes
       labels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,10 +4,10 @@ daysUntilStale: 60
 daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - 'state: pinned'
-  - 'type: security'
+  - 'state:pinned'
+  - 'type:security'
 # Label to use when marking an issue as stale
-staleLabel: 'state: wontfix'
+staleLabel: 'state:wontfix'
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
The yaml syntax in the issue templates prevented github from displaying them when clicking "New Issue"

## Related issues


## Checklist

- [x] Searched current pull requests to see if this is already addressed
- [x] Title of the pull request formatted as it would appear in release notes
<!--
"Fixed bug where result of `Get-RandomNumber` wasn't random enough"
or
"Added the ability to read input from SQL table"
 -->
- [x] Related issues (if any) are addressed in the "Related issues" section, one per line
- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#specification)
- [x] Links to any related discussions, comments, etc are included
- [ ] Appropriate labels are applied
